### PR TITLE
feat: Film Strip Preview & QoL Improvements (v3.0.25)

### DIFF
--- a/README.md
+++ b/README.md
@@ -824,6 +824,13 @@ MIT License - see LICENSE file for details.
 
 ## Changelog
 
+### v3.0.25 (Film Strip & QoL Improvements)
+
+- **🎞️ Film Strip Preview**: Backported from V2 - thumbnail strip under each prompt showing linked images
+- **🖼️ Quick Image Viewer**: Click any filmstrip thumbnail to open full-size image viewer
+- **📸 Smart Thumbnails**: Automatically uses generated thumbnails for faster loading, falls back to full images
+- **⬆️ Auto-Scroll on Pagination**: Page navigation now smoothly scrolls to top after loading
+
 ### v3.0.24 (Manual Prompt Creation)
 
 - **➕ Add Prompt Button**: New "Add Prompt" button in the admin dashboard Bulk Actions bar

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "promptmanager"
 description = "A powerful ComfyUI custom node that extends the standard text encoder with persistent prompt storage, advanced search capabilities, and an automatic image gallery system using SQLite."
-version = "3.0.24"
+version = "3.0.25"
 license = {file = "LICENSE"}
 dependencies = ["# Core dependencies for PromptManager", "# Note: Most dependencies are already included with ComfyUI", "# Already included with Python standard library:", "# - sqlite3", "# - hashlib", "# - json", "# - datetime", "# - os", "# - typing", "# - threading", "# - uuid", "# Required for gallery functionality:", "watchdog>=2.1.0              # For file system monitoring", "Pillow>=8.0.0                # For image metadata extraction (usually included with ComfyUI)", "# Optional dependencies for enhanced search functionality:", "# fuzzywuzzy[speedup]>=0.18.0  # For fuzzy string matching (optional)", "# sqlalchemy>=1.4.0            # For advanced ORM features (optional)", "# Development dependencies (optional):", "# pytest>=6.0.0                # For running tests", "# black>=22.0.0                # For code formatting", "# flake8>=4.0.0                # For linting", "# mypy>=0.910                   # For type checking"]
 


### PR DESCRIPTION
## Summary

Backports the film strip feature from V2 and adds quality of life improvements to the admin dashboard.

### New Features
- **🎞️ Film Strip Preview**: Thumbnail strip under each prompt showing linked images
- **🖼️ Quick Image Viewer**: Click any filmstrip thumbnail to open full-size image viewer
- **📸 Smart Thumbnails**: Automatically uses generated thumbnails for faster loading, falls back to full images
- **⬆️ Auto-Scroll on Pagination**: Page navigation now smoothly scrolls to top after loading

### Technical Changes
- Added film strip CSS styles with size variants (small/medium/large)
- Added JavaScript functions for loading and rendering film strips
- Integrated with existing ViewerJS for image viewing
- Thumbnail URL construction with fallback to full-size images
- Removed debug console.log statements from star rating

## Test Plan
- [ ] Verify film strip appears under prompts with linked images
- [ ] Click thumbnail opens image viewer at correct index
- [ ] Thumbnails load when available, fallback to full images works
- [ ] Pagination scrolls to top after page change
- [ ] "+N more" indicator opens gallery view