### PR TITLE
fix(admin): use correct endpoint for saving new prompts

### DIFF
--- a/web/admin.html
+++ b/web/admin.html
@@ -4652,7 +4652,7 @@ Seed: ${this.currentMetadata.seed || 'Unknown'}`;
                 }
 
                 try {
-                    const response = await fetch('/prompt_manager/prompts', {
+                    const response = await fetch('/prompt_manager/save', {
                         method: 'POST',
                         headers: { 'Content-Type': 'application/json' },
                         body: JSON.stringify({


### PR DESCRIPTION
Change the saveNewPrompt() function to use /prompt_manager/save instead of /prompt_manager/prompts which has no POST handler.

This was causing a 405 Method Not Allowed error when trying to add new prompts from the admin interface.

Fixes #89