### PR TITLE
fix: restore IS_CHANGED to enable proper branch execution

### DIFF
--- a/prompt_manager.py
+++ b/prompt_manager.py
@@ -492,6 +492,19 @@ class PromptManager(ComfyNodeABC):
         """
         self.cleanup_gallery_system()
 
-    # NOTE: IS_CHANGED intentionally removed to match CLIPTextEncode behavior
-    # ComfyUI's default caching (based on input values) should handle cache invalidation
-    # The previous IS_CHANGED implementation was causing input/cache mismatch issues
+    @classmethod
+    def IS_CHANGED(cls, clip, text="", category="", tags="", search_text="",
+                   prepend_text="", append_text="", **kwargs):
+        """
+        ComfyUI method to determine if node needs re-execution.
+
+        Returns a hash of input values that affect the conditioning output.
+        This enables proper branch execution - only re-execute when inputs change.
+        """
+        import hashlib
+
+        # Combine all text inputs that affect the conditioning output
+        # Note: search_text doesn't affect output, so it's excluded
+        combined = f"{text}|{prepend_text}|{append_text}"
+
+        return hashlib.sha256(combined.encode()).hexdigest()

--- a/prompt_manager_text.py
+++ b/prompt_manager_text.py
@@ -456,6 +456,19 @@ class PromptManagerText(ComfyNodeABC):
         """
         self.cleanup_gallery_system()
 
-    # NOTE: IS_CHANGED intentionally removed to match CLIPTextEncode behavior
-    # ComfyUI's default caching (based on input values) should handle cache invalidation
-    # The previous IS_CHANGED implementation was causing input/cache mismatch issues
+    @classmethod
+    def IS_CHANGED(cls, text="", category="", tags="", search_text="",
+                   prepend_text="", append_text="", **kwargs):
+        """
+        ComfyUI method to determine if node needs re-execution.
+
+        Returns a hash of input values that affect the text output.
+        This enables proper branch execution - only re-execute when inputs change.
+        """
+        import hashlib
+
+        # Combine all text inputs that affect the output
+        # Note: search_text doesn't affect output, so it's excluded
+        combined = f"{text}|{prepend_text}|{append_text}"
+
+        return hashlib.sha256(combined.encode()).hexdigest()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "promptmanager"
 description = "A powerful ComfyUI custom node that extends the standard text encoder with persistent prompt storage, advanced search capabilities, and an automatic image gallery system using SQLite."
-version = "3.0.29"
+version = "3.0.30"
 license = {file = "LICENSE"}
 dependencies = ["# Core dependencies for PromptManager", "# Note: Most dependencies are already included with ComfyUI", "# Already included with Python standard library:", "# - sqlite3", "# - hashlib", "# - json", "# - datetime", "# - os", "# - typing", "# - threading", "# - uuid", "# Required for gallery functionality:", "watchdog>=2.1.0              # For file system monitoring", "Pillow>=8.0.0                # For image metadata extraction (usually included with ComfyUI)", "# Optional dependencies for enhanced search functionality:", "# fuzzywuzzy[speedup]>=0.18.0  # For fuzzy string matching (optional)", "# sqlalchemy>=1.4.0            # For advanced ORM features (optional)", "# Development dependencies (optional):", "# pytest>=6.0.0                # For running tests", "# black>=22.0.0                # For code formatting", "# flake8>=4.0.0                # For linting", "# mypy>=0.910                   # For type checking"]
 


### PR DESCRIPTION
## Summary
- Restores `IS_CHANGED` method to both `PromptManager` and `PromptManagerText` nodes
- Fixes branch execution feature that was broken in PR #91

## Problem
The removal of `IS_CHANGED` in PR #91 caused ComfyUI to always re-execute the entire graph instead of only the changed branches. This broke a core ComfyUI optimization feature.

## Solution
`IS_CHANGED` returns a hash of text inputs (`text`, `prepend_text`, `append_text`). When these inputs haven't changed, the hash stays the same and ComfyUI knows it can skip re-execution of that node and its downstream nodes.

Fixes #94

## Test plan
- [x] Verified branch execution works correctly after the fix
- [ ] User should restart ComfyUI after updating