### PR TITLE
fix: forward partial execution targets in queuePrompt wrapper

### DIFF
--- a/prompt_manager.py
+++ b/prompt_manager.py
@@ -169,13 +169,6 @@ class PromptManager(ComfyNodeABC):
         Raises:
             RuntimeError: If clip input is invalid
         """
-        # Debug: Log text being encoded - this should print EVERY time the node executes
-        import time
-        print(f"\n{'='*60}")
-        print(f"[PromptManager] encode_prompt() CALLED at {time.time()}")
-        print(f"[PromptManager] text = {repr(text)[:100]}")
-        print(f"{'='*60}\n")
-
         # Combine prepend, main text, and append text
         final_text = ""
         if prepend_text and prepend_text.strip():


### PR DESCRIPTION
The api.queuePrompt wrapper introduced in PR #91 only forwarded 2 of 3 arguments, dropping the options object that carries partialExecutionTargets. This caused the server to execute all output nodes instead of just the targeted branch.

Also removes debug console.log and print statements added during development.

Fixes #94