### PR TITLE
feat(tags): Phase 2 tag management enhancements

### DIFF
--- a/web/admin.html
+++ b/web/admin.html
@@ -181,6 +181,9 @@
             </div>
         </header>
 
+        <!-- Dashboard View -->
+        <div id="dashboardView">
+
         <!-- Stats Grid -->
         <div class="px-6 py-6">
             <div class="max-w-7xl mx-auto">
@@ -207,7 +210,8 @@
                             </div>
                         </div>
                     </div>
-                    <div class="bg-gradient-to-br from-gray-800 to-gray-850 rounded-xl p-6 border border-gray-700">
+                    <div class="bg-gradient-to-br from-gray-800 to-gray-850 rounded-xl p-6 border border-gray-700 cursor-pointer hover:border-green-500/50 transition-colors"
+                         onclick="window.location.hash = '#/tags'" title="Click to manage tags">
                         <div class="flex items-center justify-between">
                             <div>
                                 <p class="text-gray-400 text-sm font-medium">Unique Tags</p>
@@ -417,6 +421,84 @@
                 </div>
             </div>
         </div>
+        </div><!-- /dashboardView -->
+
+        <!-- Tags Page View -->
+        <div id="tagsPageView" class="hidden flex-1 flex flex-col">
+            <!-- Tags Header -->
+            <div class="px-6 py-4 border-b border-gray-700/50 bg-gray-850/50">
+                <div class="max-w-7xl mx-auto flex items-center justify-between">
+                    <div class="flex items-center space-x-4">
+                        <button onclick="window.location.hash=''" class="text-gray-400 hover:text-white transition-colors text-sm flex items-center space-x-1">
+                            <span>&larr;</span><span>Dashboard</span>
+                        </button>
+                        <h2 class="text-xl font-semibold text-gray-100">Tags</h2>
+                        <span id="tagsTotalBadge" class="text-sm font-medium text-gray-400 bg-gray-700 px-3 py-1 rounded-full">0 tags</span>
+                    </div>
+                    <div id="filterModeToggle" class="hidden items-center space-x-2">
+                        <span class="text-sm text-gray-400">Filter:</span>
+                        <button id="filterModeAnd" class="px-3 py-1 text-xs font-medium rounded bg-green-600 text-white">AND</button>
+                        <button id="filterModeOr" class="px-3 py-1 text-xs font-medium rounded bg-gray-700 text-gray-300 hover:bg-gray-600">OR</button>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Two-Panel Layout -->
+            <div class="flex-1 flex overflow-hidden">
+                <!-- Left Panel: Tag List -->
+                <div class="w-80 flex-shrink-0 border-r border-gray-700/50 flex flex-col bg-gray-850/30">
+                    <!-- Tag Search & Sort -->
+                    <div class="p-4 space-y-3 border-b border-gray-700/30">
+                        <input type="text" id="tagSearchInput" placeholder="Search tags..."
+                               class="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-lg text-gray-100 text-sm focus:ring-2 focus:ring-green-500 focus:border-green-500">
+                        <select id="tagSortSelect" class="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-lg text-gray-100 text-sm">
+                            <option value="alpha_asc">A &rarr; Z</option>
+                            <option value="alpha_desc">Z &rarr; A</option>
+                            <option value="count_desc">Most Used</option>
+                            <option value="count_asc">Least Used</option>
+                        </select>
+                    </div>
+                    <!-- Tag List -->
+                    <div id="tagsListContainer" class="flex-1 overflow-y-auto custom-scrollbar">
+                        <div id="tagsList" class="p-2 space-y-1"></div>
+                        <div id="tagsLoader" class="p-4 text-center hidden">
+                            <div class="w-6 h-6 border-2 border-green-500/30 border-t-green-500 rounded-full animate-spin mx-auto"></div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Right Panel: Prompts Display -->
+                <div class="flex-1 flex flex-col overflow-hidden">
+                    <!-- Active Tags Pills -->
+                    <div id="activeTagsPills" class="px-6 py-3 border-b border-gray-700/30 hidden">
+                        <div class="flex flex-wrap gap-2 items-center">
+                            <span class="text-sm text-gray-400 mr-1">Filtering:</span>
+                            <div id="tagPillsContainer" class="flex flex-wrap gap-2"></div>
+                            <span id="tagPromptsCountBadge" class="text-xs text-gray-500 ml-auto"></span>
+                        </div>
+                    </div>
+                    <!-- Prompts Grid -->
+                    <div id="tagPromptsContainer" class="flex-1 overflow-y-auto custom-scrollbar">
+                        <div id="tagPromptsGrid" class="p-6 grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4"></div>
+                        <div id="tagPromptsLoader" class="p-4 text-center hidden">
+                            <div class="w-6 h-6 border-2 border-green-500/30 border-t-green-500 rounded-full animate-spin mx-auto"></div>
+                        </div>
+                    </div>
+                    <!-- Empty State -->
+                    <div id="tagPromptsEmpty" class="flex-1 flex items-center justify-center">
+                        <div class="text-center text-gray-500">
+                            <span class="text-4xl block mb-3">🏷️</span>
+                            <p class="text-lg font-medium">Select a tag to view prompts</p>
+                            <p class="text-sm mt-1">Click a tag from the list or use checkboxes for multi-tag filtering</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        <!-- Context Menu for Tag Operations -->
+        <div id="tagContextMenu" class="hidden fixed z-50 bg-gray-800 border border-gray-600 rounded-lg shadow-xl py-1 min-w-[160px]">
+        </div>
+        </div><!-- /tagsPageView -->
+
     </div>
 
     <!-- Settings Modal -->
@@ -1375,12 +1457,50 @@ No sentences, no commentary, no captions. Only tags. Keep length short but descr
                     totalPages: 1
                 };
 
+                this.tagsPage = null;
+
                 this.init();
             }
 
             init() {
                 this.bindEvents();
+                this.initRouter();
                 this.loadInitialData();
+            }
+
+            initRouter() {
+                window.addEventListener('hashchange', () => this.handleRoute());
+                this.handleRoute();
+            }
+
+            handleRoute() {
+                const hash = window.location.hash;
+                if (hash === '#/tags' || hash.startsWith('#/tags/')) {
+                    this.showTagsPage();
+                } else {
+                    this.showDashboard();
+                }
+            }
+
+            showDashboard() {
+                const dashboard = document.getElementById('dashboardView');
+                const tagsPage = document.getElementById('tagsPageView');
+                if (dashboard) dashboard.classList.remove('hidden');
+                if (tagsPage) tagsPage.classList.add('hidden');
+            }
+
+            showTagsPage() {
+                const dashboard = document.getElementById('dashboardView');
+                const tagsPage = document.getElementById('tagsPageView');
+                if (dashboard) dashboard.classList.add('hidden');
+                if (tagsPage) tagsPage.classList.remove('hidden');
+
+                // Lazy-initialize TagsPageManager
+                if (!this.tagsPage && typeof TagsPageManager !== 'undefined') {
+                    this.tagsPage = new TagsPageManager(this);
+                } else if (this.tagsPage) {
+                    this.tagsPage.loadTagsList();
+                }
             }
 
             bindEvents() {
@@ -5497,5 +5617,6 @@ Seed: ${this.currentMetadata.seed || 'Unknown'}`;
             }
         });
     </script>
+    <script src="/prompt_manager/js/tags-page.js"></script>
 </body>
 </html>

--- a/web/js/tags-page.js
+++ b/web/js/tags-page.js
@@ -1,0 +1,994 @@
+/**
+ * TagsPageManager - Tag management page with two-panel layout
+ * Left: searchable/sortable tag list with counts + infinite scroll
+ * Right: prompt cards with image thumbnails for selected tag(s)
+ */
+class TagsPageManager {
+    constructor(admin) {
+        this.admin = admin;
+
+        // Tag list state
+        this.tags = [];
+        this.tagOffset = 0;
+        this.tagLimit = 50;
+        this.hasMoreTags = false;
+        this.tagSearch = '';
+        this.tagSort = 'alpha_asc';
+        this.isLoadingTags = false;
+        this.maxTagCount = 1;
+        this.untaggedCount = 0;
+
+        // Selection state
+        this.selectedTags = [];
+        this.filterMode = 'and';
+
+        // Prompts state
+        this.prompts = [];
+        this.promptOffset = 0;
+        this.promptLimit = 20;
+        this.promptTotal = 0;
+        this.hasMorePrompts = false;
+        this.isLoadingPrompts = false;
+
+        // Observers
+        this.tagObserver = null;
+        this.promptObserver = null;
+
+        // Debounce timer
+        this.searchTimer = null;
+
+        // Context menu state
+        this.contextMenuTag = null;
+
+        this.bindEvents();
+        this.initInfiniteScroll();
+        this.buildContextMenu();
+        this.parseUrlState();
+        this.loadTagsList();
+    }
+
+    // ── URL State Sync ────────────────────────────────────────
+
+    parseUrlState() {
+        const hash = window.location.hash;
+        if (!hash.startsWith('#/tags/')) return;
+
+        const rest = hash.substring('#/tags/'.length);
+        if (!rest) return;
+
+        // Parse query params from hash (e.g., #/tags/landscape,portrait?mode=or)
+        const [tagsPart, queryPart] = rest.split('?');
+        const tagNames = tagsPart.split(',').map(t => decodeURIComponent(t.trim())).filter(Boolean);
+
+        if (tagNames.length > 0) {
+            this.selectedTags = tagNames;
+        }
+
+        if (queryPart) {
+            const params = new URLSearchParams(queryPart);
+            const mode = params.get('mode');
+            if (mode === 'or') this.filterMode = 'or';
+        }
+    }
+
+    updateUrlHash() {
+        if (this.selectedTags.length === 0) {
+            if (window.location.hash !== '#/tags') {
+                history.replaceState(null, '', '#/tags');
+            }
+            return;
+        }
+
+        const tagsStr = this.selectedTags.map(t => encodeURIComponent(t)).join(',');
+        let hash = `#/tags/${tagsStr}`;
+        if (this.filterMode === 'or' && this.selectedTags.length > 1) {
+            hash += '?mode=or';
+        }
+        if (window.location.hash !== hash) {
+            history.replaceState(null, '', hash);
+        }
+    }
+
+    // ── Tag List Methods ──────────────────────────────────────
+
+    async loadTagsList() {
+        if (this.isLoadingTags) return;
+        this.isLoadingTags = true;
+        this.tagOffset = 0;
+        this.tags = [];
+
+        try {
+            const params = new URLSearchParams({
+                limit: this.tagLimit,
+                offset: 0,
+                sort: this.tagSort
+            });
+            if (this.tagSearch) params.set('search', this.tagSearch);
+
+            const resp = await fetch(`/prompt_manager/tags/stats?${params}`);
+            const data = await resp.json();
+
+            if (data.success) {
+                this.tags = data.tags;
+                this.hasMoreTags = data.pagination.has_more;
+                this.tagOffset = this.tagLimit;
+                this.untaggedCount = data.untagged_count || 0;
+                this.maxTagCount = Math.max(1, ...this.tags.map(t => t.count));
+                this.renderTagsList();
+
+                const badge = document.getElementById('tagsTotalBadge');
+                if (badge) badge.textContent = `${data.pagination.total} tags`;
+
+                // If we have pre-selected tags from URL, load prompts
+                if (this.selectedTags.length > 0) {
+                    this.updateActiveTagPills();
+                    this.loadTagPrompts();
+                }
+            }
+        } catch (err) {
+            console.error('Failed to load tags:', err);
+        } finally {
+            this.isLoadingTags = false;
+        }
+    }
+
+    async loadMoreTags() {
+        if (this.isLoadingTags || !this.hasMoreTags) return;
+        this.isLoadingTags = true;
+
+        const loader = document.getElementById('tagsLoader');
+        if (loader) loader.classList.remove('hidden');
+
+        try {
+            const params = new URLSearchParams({
+                limit: this.tagLimit,
+                offset: this.tagOffset,
+                sort: this.tagSort
+            });
+            if (this.tagSearch) params.set('search', this.tagSearch);
+
+            const resp = await fetch(`/prompt_manager/tags/stats?${params}`);
+            const data = await resp.json();
+
+            if (data.success) {
+                this.tags = this.tags.concat(data.tags);
+                this.hasMoreTags = data.pagination.has_more;
+                this.tagOffset += this.tagLimit;
+                this.maxTagCount = Math.max(1, ...this.tags.map(t => t.count));
+                this.renderTagsList();
+            }
+        } catch (err) {
+            console.error('Failed to load more tags:', err);
+        } finally {
+            this.isLoadingTags = false;
+            if (loader) loader.classList.add('hidden');
+        }
+    }
+
+    renderTagsList() {
+        const container = document.getElementById('tagsList');
+        if (!container) return;
+
+        const fragment = document.createDocumentFragment();
+
+        // Untagged entry at top
+        if (this.untaggedCount > 0) {
+            fragment.appendChild(this.createUntaggedElement());
+        }
+
+        this.tags.forEach(tag => {
+            fragment.appendChild(this.createTagElement(tag));
+        });
+        container.replaceChildren(fragment);
+    }
+
+    createUntaggedElement() {
+        const isSelected = this.selectedTags.includes('__untagged__');
+        const div = document.createElement('div');
+        div.className = `flex items-center px-3 py-2 rounded-lg cursor-pointer border transition-all duration-200 relative overflow-hidden ${
+            isSelected ? 'bg-yellow-600/20 border-yellow-500/50' : 'border-transparent hover:bg-gray-700/50'
+        }`;
+
+        div.addEventListener('click', () => this.selectTag('__untagged__'));
+
+        const icon = document.createElement('span');
+        icon.className = 'mr-3 text-sm';
+        icon.textContent = '\u2205';
+
+        const nameSpan = document.createElement('span');
+        nameSpan.className = 'flex-1 text-sm text-yellow-300 italic truncate';
+        nameSpan.textContent = '[untagged]';
+
+        const countSpan = document.createElement('span');
+        countSpan.className = 'text-xs text-gray-500 ml-2 font-mono';
+        countSpan.textContent = this.untaggedCount;
+
+        div.appendChild(icon);
+        div.appendChild(nameSpan);
+        div.appendChild(countSpan);
+
+        return div;
+    }
+
+    createTagElement(tag) {
+        const isSelected = this.selectedTags.includes(tag.name);
+        const div = document.createElement('div');
+        div.className = `flex items-center px-3 py-2 rounded-lg cursor-pointer border transition-all duration-200 relative overflow-hidden group ${
+            isSelected ? 'bg-green-600/20 border-green-500/50' : 'border-transparent hover:bg-gray-700/50'
+        }`;
+        div.dataset.tagName = tag.name;
+
+        // Usage bar (background)
+        const barWidth = (tag.count / this.maxTagCount) * 100;
+        const bar = document.createElement('div');
+        bar.className = 'absolute inset-y-0 left-0 bg-green-500/8 pointer-events-none transition-all duration-300';
+        bar.style.width = barWidth + '%';
+        div.appendChild(bar);
+
+        const tagName = tag.name;
+        div.addEventListener('click', () => this.selectTag(tagName));
+        div.addEventListener('contextmenu', (e) => {
+            e.preventDefault();
+            this.showContextMenu(e, tagName);
+        });
+
+        const checkbox = document.createElement('input');
+        checkbox.type = 'checkbox';
+        checkbox.className = 'tag-filter-checkbox mr-3 rounded border-gray-500 bg-gray-700 text-green-500 focus:ring-green-500 cursor-pointer relative z-10';
+        checkbox.checked = isSelected;
+        checkbox.dataset.tag = tag.name;
+        checkbox.addEventListener('click', (e) => {
+            e.stopPropagation();
+            this.toggleTagFilter(tagName);
+        });
+
+        const nameSpan = document.createElement('span');
+        nameSpan.className = 'flex-1 text-sm text-gray-200 truncate relative z-10';
+        nameSpan.textContent = tag.name;
+
+        const countSpan = document.createElement('span');
+        countSpan.className = 'text-xs text-gray-500 ml-2 font-mono relative z-10';
+        countSpan.textContent = tag.count;
+
+        div.appendChild(checkbox);
+        div.appendChild(nameSpan);
+        div.appendChild(countSpan);
+
+        return div;
+    }
+
+    // ── Context Menu ──────────────────────────────────────────
+
+    buildContextMenu() {
+        const menu = document.getElementById('tagContextMenu');
+        if (!menu) return;
+
+        const items = [
+            { label: 'Rename Tag', icon: '\u270F\uFE0F', action: () => this.renameTag(this.contextMenuTag) },
+            { label: 'Delete Tag', icon: '\uD83D\uDDD1\uFE0F', action: () => this.deleteTag(this.contextMenuTag) },
+            { label: 'Merge Into\u2026', icon: '\uD83D\uDD00', action: () => this.mergeTag(this.contextMenuTag) }
+        ];
+
+        const fragment = document.createDocumentFragment();
+        items.forEach(item => {
+            const btn = document.createElement('button');
+            btn.className = 'w-full text-left px-4 py-2 text-sm text-gray-200 hover:bg-gray-700 flex items-center space-x-2';
+            const iconSpan = document.createElement('span');
+            iconSpan.textContent = item.icon;
+            const labelSpan = document.createElement('span');
+            labelSpan.textContent = item.label;
+            btn.appendChild(iconSpan);
+            btn.appendChild(labelSpan);
+            btn.addEventListener('click', () => {
+                this.hideContextMenu();
+                item.action();
+            });
+            fragment.appendChild(btn);
+        });
+        menu.replaceChildren(fragment);
+
+        // Close on click outside
+        document.addEventListener('click', (e) => {
+            if (!menu.contains(e.target)) this.hideContextMenu();
+        });
+        document.addEventListener('keydown', (e) => {
+            if (e.key === 'Escape') this.hideContextMenu();
+        });
+    }
+
+    showContextMenu(e, tagName) {
+        const menu = document.getElementById('tagContextMenu');
+        if (!menu) return;
+
+        this.contextMenuTag = tagName;
+
+        // Position at mouse, clamped to viewport
+        let x = e.clientX;
+        let y = e.clientY;
+        menu.classList.remove('hidden');
+
+        const rect = menu.getBoundingClientRect();
+        if (x + rect.width > window.innerWidth) x = window.innerWidth - rect.width - 8;
+        if (y + rect.height > window.innerHeight) y = window.innerHeight - rect.height - 8;
+
+        menu.style.left = x + 'px';
+        menu.style.top = y + 'px';
+    }
+
+    hideContextMenu() {
+        const menu = document.getElementById('tagContextMenu');
+        if (menu) menu.classList.add('hidden');
+        this.contextMenuTag = null;
+    }
+
+    // ── Tag Operations ────────────────────────────────────────
+
+    async renameTag(tagName) {
+        if (!tagName) return;
+        const newName = prompt(`Rename tag "${tagName}" to:`, tagName);
+        if (!newName || newName.trim() === '' || newName.trim() === tagName) return;
+
+        try {
+            const resp = await fetch(`/prompt_manager/tags/${encodeURIComponent(tagName)}`, {
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ new_name: newName.trim() })
+            });
+            const data = await resp.json();
+            if (data.success) {
+                this.admin.showNotification(`Renamed "${tagName}" → "${newName.trim()}" (${data.affected_count} prompts)`, 'success');
+                // Update selectedTags if the renamed tag was selected
+                const idx = this.selectedTags.indexOf(tagName);
+                if (idx >= 0) this.selectedTags[idx] = newName.trim();
+                this.updateUrlHash();
+                this.loadTagsList();
+                if (this.selectedTags.length > 0) this.loadTagPrompts();
+            } else {
+                this.admin.showNotification(data.error || 'Rename failed', 'error');
+            }
+        } catch (err) {
+            console.error('Rename tag error:', err);
+            this.admin.showNotification('Failed to rename tag', 'error');
+        }
+    }
+
+    async deleteTag(tagName) {
+        if (!tagName) return;
+        if (!confirm(`Delete tag "${tagName}" from all prompts? This cannot be undone.`)) return;
+
+        try {
+            const resp = await fetch(`/prompt_manager/tags/${encodeURIComponent(tagName)}`, {
+                method: 'DELETE'
+            });
+            const data = await resp.json();
+            if (data.success) {
+                this.admin.showNotification(`Deleted tag "${tagName}" from ${data.affected_count} prompts`, 'success');
+                this.selectedTags = this.selectedTags.filter(t => t !== tagName);
+                this.updateUrlHash();
+                this.loadTagsList();
+                if (this.selectedTags.length > 0) {
+                    this.loadTagPrompts();
+                } else {
+                    this.clearPrompts();
+                    this.updateActiveTagPills();
+                }
+            } else {
+                this.admin.showNotification(data.error || 'Delete failed', 'error');
+            }
+        } catch (err) {
+            console.error('Delete tag error:', err);
+            this.admin.showNotification('Failed to delete tag', 'error');
+        }
+    }
+
+    async mergeTag(tagName) {
+        if (!tagName) return;
+        const targetTag = prompt(`Merge "${tagName}" into which tag?`);
+        if (!targetTag || targetTag.trim() === '' || targetTag.trim() === tagName) return;
+
+        try {
+            const resp = await fetch('/prompt_manager/tags/merge', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ source_tags: [tagName], target_tag: targetTag.trim() })
+            });
+            const data = await resp.json();
+            if (data.success) {
+                this.admin.showNotification(
+                    `Merged "${tagName}" → "${targetTag.trim()}" (${data.affected_count} prompts)`,
+                    'success'
+                );
+                this.selectedTags = this.selectedTags.filter(t => t !== tagName);
+                this.updateUrlHash();
+                this.loadTagsList();
+                if (this.selectedTags.length > 0) {
+                    this.loadTagPrompts();
+                } else {
+                    this.clearPrompts();
+                    this.updateActiveTagPills();
+                }
+            } else {
+                this.admin.showNotification(data.error || 'Merge failed', 'error');
+            }
+        } catch (err) {
+            console.error('Merge tag error:', err);
+            this.admin.showNotification('Failed to merge tag', 'error');
+        }
+    }
+
+    // ── Tag Selection ─────────────────────────────────────────
+
+    selectTag(name) {
+        this.selectedTags = [name];
+        this.renderTagsList();
+        this.updateActiveTagPills();
+        this.updateUrlHash();
+        this.loadTagPrompts();
+    }
+
+    toggleTagFilter(name) {
+        const idx = this.selectedTags.indexOf(name);
+        if (idx >= 0) {
+            this.selectedTags.splice(idx, 1);
+        } else {
+            // Don't allow mixing untagged with regular tags
+            if (name === '__untagged__') {
+                this.selectedTags = ['__untagged__'];
+            } else {
+                this.selectedTags = this.selectedTags.filter(t => t !== '__untagged__');
+                this.selectedTags.push(name);
+            }
+        }
+
+        this.renderTagsList();
+        this.updateActiveTagPills();
+        this.updateUrlHash();
+
+        if (this.selectedTags.length > 0) {
+            this.loadTagPrompts();
+        } else {
+            this.clearPrompts();
+        }
+    }
+
+    setFilterMode(mode) {
+        this.filterMode = mode;
+        const andBtn = document.getElementById('filterModeAnd');
+        const orBtn = document.getElementById('filterModeOr');
+
+        if (mode === 'and') {
+            andBtn.className = 'px-3 py-1 text-xs font-medium rounded bg-green-600 text-white';
+            orBtn.className = 'px-3 py-1 text-xs font-medium rounded bg-gray-700 text-gray-300 hover:bg-gray-600';
+        } else {
+            orBtn.className = 'px-3 py-1 text-xs font-medium rounded bg-green-600 text-white';
+            andBtn.className = 'px-3 py-1 text-xs font-medium rounded bg-gray-700 text-gray-300 hover:bg-gray-600';
+        }
+
+        this.updateUrlHash();
+
+        if (this.selectedTags.length > 0) {
+            this.loadTagPrompts();
+        }
+    }
+
+    updateActiveTagPills() {
+        const pillsArea = document.getElementById('activeTagsPills');
+        const pillsContainer = document.getElementById('tagPillsContainer');
+        const filterToggle = document.getElementById('filterModeToggle');
+        const emptyState = document.getElementById('tagPromptsEmpty');
+        const countBadge = document.getElementById('tagPromptsCountBadge');
+
+        if (this.selectedTags.length === 0) {
+            if (pillsArea) pillsArea.classList.add('hidden');
+            if (filterToggle) filterToggle.classList.add('hidden');
+            if (filterToggle) filterToggle.classList.remove('flex');
+            if (emptyState) emptyState.classList.remove('hidden');
+            if (countBadge) countBadge.textContent = '';
+            return;
+        }
+
+        if (emptyState) emptyState.classList.add('hidden');
+        if (pillsArea) pillsArea.classList.remove('hidden');
+
+        // Show AND/OR toggle only for multi-tag selection (not untagged)
+        const isUntagged = this.selectedTags.includes('__untagged__');
+        if (this.selectedTags.length > 1 && !isUntagged) {
+            if (filterToggle) {
+                filterToggle.classList.remove('hidden');
+                filterToggle.classList.add('flex');
+            }
+        } else {
+            if (filterToggle) {
+                filterToggle.classList.add('hidden');
+                filterToggle.classList.remove('flex');
+            }
+        }
+
+        // Build pills using safe DOM methods
+        if (pillsContainer) {
+            const fragment = document.createDocumentFragment();
+            this.selectedTags.forEach(tag => {
+                const pill = document.createElement('span');
+                const isUntaggedPill = tag === '__untagged__';
+                pill.className = `inline-flex items-center px-3 py-1 rounded-full text-sm ${
+                    isUntaggedPill
+                        ? 'bg-yellow-600/20 text-yellow-300 border border-yellow-500/30'
+                        : 'bg-green-600/20 text-green-300 border border-green-500/30'
+                }`;
+
+                const text = document.createTextNode(isUntaggedPill ? '[untagged]' : tag);
+                pill.appendChild(text);
+
+                const btn = document.createElement('button');
+                btn.className = isUntaggedPill ? 'ml-2 text-yellow-400 hover:text-white' : 'ml-2 text-green-400 hover:text-white';
+                btn.textContent = '\u00d7';
+                btn.addEventListener('click', () => this.removeTagFromFilter(tag));
+                pill.appendChild(btn);
+
+                fragment.appendChild(pill);
+            });
+            pillsContainer.replaceChildren(fragment);
+        }
+    }
+
+    removeTagFromFilter(name) {
+        this.selectedTags = this.selectedTags.filter(t => t !== name);
+        this.renderTagsList();
+        this.updateActiveTagPills();
+        this.updateUrlHash();
+
+        if (this.selectedTags.length > 0) {
+            this.loadTagPrompts();
+        } else {
+            this.clearPrompts();
+        }
+    }
+
+    // ── Prompts Display ───────────────────────────────────────
+
+    async loadTagPrompts() {
+        if (this.isLoadingPrompts) return;
+        if (this.selectedTags.length === 0) return;
+
+        this.isLoadingPrompts = true;
+        this.promptOffset = 0;
+        this.prompts = [];
+
+        const grid = document.getElementById('tagPromptsGrid');
+        if (grid) {
+            grid.replaceChildren();
+            const spinner = document.createElement('div');
+            spinner.className = 'col-span-full text-center py-8';
+            const spinEl = document.createElement('div');
+            spinEl.className = 'w-8 h-8 border-2 border-green-500/30 border-t-green-500 rounded-full animate-spin mx-auto';
+            spinner.appendChild(spinEl);
+            grid.appendChild(spinner);
+        }
+
+        try {
+            let url;
+            const params = new URLSearchParams({
+                limit: this.promptLimit,
+                offset: 0
+            });
+
+            const isUntagged = this.selectedTags.includes('__untagged__');
+
+            if (isUntagged) {
+                params.set('untagged', 'true');
+                url = `/prompt_manager/tags/filter?${params}`;
+            } else if (this.selectedTags.length === 1) {
+                url = `/prompt_manager/tags/${encodeURIComponent(this.selectedTags[0])}/prompts?${params}`;
+            } else {
+                params.set('tags', this.selectedTags.join(','));
+                params.set('mode', this.filterMode);
+                url = `/prompt_manager/tags/filter?${params}`;
+            }
+
+            const resp = await fetch(url);
+            const data = await resp.json();
+
+            if (data.success) {
+                this.prompts = data.prompts;
+                this.hasMorePrompts = data.pagination.has_more;
+                this.promptTotal = data.pagination.total;
+                this.promptOffset = this.promptLimit;
+                this.renderTagPrompts();
+                this.updatePromptCountBadge();
+            }
+        } catch (err) {
+            console.error('Failed to load tag prompts:', err);
+            if (grid) {
+                grid.replaceChildren();
+                const errDiv = document.createElement('div');
+                errDiv.className = 'col-span-full text-center py-8 text-red-400';
+                errDiv.textContent = 'Failed to load prompts';
+                grid.appendChild(errDiv);
+            }
+        } finally {
+            this.isLoadingPrompts = false;
+        }
+    }
+
+    async loadMoreTagPrompts() {
+        if (this.isLoadingPrompts || !this.hasMorePrompts) return;
+        this.isLoadingPrompts = true;
+
+        const loader = document.getElementById('tagPromptsLoader');
+        if (loader) loader.classList.remove('hidden');
+
+        try {
+            const params = new URLSearchParams({
+                limit: this.promptLimit,
+                offset: this.promptOffset
+            });
+
+            let url;
+            const isUntagged = this.selectedTags.includes('__untagged__');
+
+            if (isUntagged) {
+                params.set('untagged', 'true');
+                url = `/prompt_manager/tags/filter?${params}`;
+            } else if (this.selectedTags.length === 1) {
+                url = `/prompt_manager/tags/${encodeURIComponent(this.selectedTags[0])}/prompts?${params}`;
+            } else {
+                params.set('tags', this.selectedTags.join(','));
+                params.set('mode', this.filterMode);
+                url = `/prompt_manager/tags/filter?${params}`;
+            }
+
+            const resp = await fetch(url);
+            const data = await resp.json();
+
+            if (data.success) {
+                this.prompts = this.prompts.concat(data.prompts);
+                this.hasMorePrompts = data.pagination.has_more;
+                this.promptOffset += this.promptLimit;
+                this.renderTagPrompts();
+                this.updatePromptCountBadge();
+            }
+        } catch (err) {
+            console.error('Failed to load more prompts:', err);
+        } finally {
+            this.isLoadingPrompts = false;
+            if (loader) loader.classList.add('hidden');
+        }
+    }
+
+    updatePromptCountBadge() {
+        const badge = document.getElementById('tagPromptsCountBadge');
+        if (badge) {
+            badge.textContent = this.promptTotal > 0
+                ? `${this.prompts.length} of ${this.promptTotal} prompts`
+                : '';
+        }
+    }
+
+    renderTagPrompts() {
+        const grid = document.getElementById('tagPromptsGrid');
+        if (!grid) return;
+
+        if (this.prompts.length === 0) {
+            grid.replaceChildren();
+            const emptyDiv = document.createElement('div');
+            emptyDiv.className = 'col-span-full text-center py-12 text-gray-500';
+            const icon = document.createElement('span');
+            icon.className = 'text-3xl block mb-2';
+            icon.textContent = '\uD83D\uDCED';
+            emptyDiv.appendChild(icon);
+            const msg = document.createElement('span');
+            msg.textContent = 'No prompts found with the selected tag(s)';
+            emptyDiv.appendChild(msg);
+            grid.appendChild(emptyDiv);
+            return;
+        }
+
+        const fragment = document.createDocumentFragment();
+        this.prompts.forEach((p, index) => {
+            const card = this.createPromptCard(p);
+            // Staggered fade-in
+            card.style.opacity = '0';
+            card.style.transform = 'translateY(8px)';
+            card.style.transition = 'opacity 0.3s ease, transform 0.3s ease';
+            card.style.transitionDelay = (index % 9) * 30 + 'ms';
+            fragment.appendChild(card);
+        });
+        grid.replaceChildren(fragment);
+
+        // Trigger animations
+        requestAnimationFrame(() => {
+            grid.querySelectorAll('.tag-prompt-card').forEach(card => {
+                card.style.opacity = '1';
+                card.style.transform = 'translateY(0)';
+            });
+        });
+    }
+
+    createPromptCard(prompt) {
+        const card = document.createElement('div');
+        card.className = 'tag-prompt-card bg-gray-800/50 rounded-xl p-4 border border-gray-700/50 hover:border-gray-600 transition-colors cursor-pointer';
+
+        // Click card → navigate to dashboard with search
+        card.addEventListener('click', () => {
+            const fragment = (prompt.text || '').substring(0, 60);
+            window.location.hash = '';
+            setTimeout(() => {
+                const searchInput = document.getElementById('searchText');
+                if (searchInput) {
+                    searchInput.value = fragment;
+                    if (this.admin && typeof this.admin.search === 'function') {
+                        this.admin.search();
+                    }
+                }
+            }, 100);
+        });
+
+        // Thumbnail row
+        if (prompt.images && prompt.images.length > 0) {
+            const thumbRow = document.createElement('div');
+            thumbRow.className = 'flex gap-2 mb-3';
+
+            prompt.images.forEach((img, imgIndex) => {
+                const imgEl = document.createElement('img');
+                imgEl.src = this.getThumbnailUrl(img);
+                imgEl.alt = '';
+                imgEl.loading = 'lazy';
+                imgEl.className = 'w-20 h-20 object-cover rounded-lg bg-gray-700 cursor-zoom-in hover:ring-2 hover:ring-green-500/50 transition-all';
+                imgEl.onerror = function() {
+                    this.onerror = null;
+                    this.src = 'data:image/svg+xml,' + encodeURIComponent('<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 80"><rect fill="#374151" width="80" height="80"/><text x="40" y="44" text-anchor="middle" fill="#6B7280" font-size="20">?</text></svg>');
+                };
+                // Click thumbnail → ViewerJS
+                imgEl.addEventListener('click', (e) => {
+                    e.stopPropagation();
+                    this.openImageViewer(prompt, imgIndex);
+                });
+                thumbRow.appendChild(imgEl);
+            });
+
+            const moreCount = (prompt.image_count || 0) - prompt.images.length;
+            if (moreCount > 0) {
+                const moreSpan = document.createElement('span');
+                moreSpan.className = 'w-20 h-20 rounded-lg bg-gray-700 flex items-center justify-center text-gray-400 text-sm font-medium cursor-zoom-in hover:bg-gray-600 transition-colors';
+                moreSpan.textContent = `+${moreCount}`;
+                moreSpan.addEventListener('click', (e) => {
+                    e.stopPropagation();
+                    this.openImageViewer(prompt, prompt.images.length);
+                });
+                thumbRow.appendChild(moreSpan);
+            }
+
+            card.appendChild(thumbRow);
+        }
+
+        // Prompt text (truncated)
+        const textP = document.createElement('p');
+        textP.className = 'text-sm text-gray-200 leading-relaxed line-clamp-3 mb-3';
+        textP.textContent = prompt.text || '';
+        card.appendChild(textP);
+
+        // Meta row
+        const metaRow = document.createElement('div');
+        metaRow.className = 'flex items-center justify-between text-xs text-gray-500 mb-2';
+
+        const metaLeft = document.createElement('div');
+        metaLeft.className = 'flex items-center space-x-3';
+
+        if (prompt.category) {
+            const catSpan = document.createElement('span');
+            catSpan.className = 'px-2 py-0.5 bg-purple-600/20 text-purple-300 rounded';
+            catSpan.textContent = prompt.category;
+            metaLeft.appendChild(catSpan);
+        }
+
+        if (prompt.created_at) {
+            const dateSpan = document.createElement('span');
+            dateSpan.textContent = new Date(prompt.created_at).toLocaleDateString();
+            metaLeft.appendChild(dateSpan);
+        }
+
+        // Rating stars
+        const rating = prompt.rating || 0;
+        const starsSpan = document.createElement('span');
+        starsSpan.className = 'flex';
+        for (let i = 1; i <= 5; i++) {
+            const star = document.createElement('span');
+            star.className = i <= rating ? 'text-yellow-400' : 'text-gray-600';
+            star.textContent = '\u2605';
+            starsSpan.appendChild(star);
+        }
+        metaLeft.appendChild(starsSpan);
+
+        metaRow.appendChild(metaLeft);
+
+        if (prompt.image_count) {
+            const imgCount = document.createElement('span');
+            imgCount.className = 'text-gray-500';
+            imgCount.textContent = `${prompt.image_count} img${prompt.image_count !== 1 ? 's' : ''}`;
+            metaRow.appendChild(imgCount);
+        }
+
+        card.appendChild(metaRow);
+
+        // Tags
+        if (prompt.tags && prompt.tags.length > 0) {
+            const tagsDiv = document.createElement('div');
+            tagsDiv.className = 'flex flex-wrap gap-1 mt-2';
+            prompt.tags.forEach(tag => {
+                const tagSpan = document.createElement('span');
+                const isActive = this.selectedTags.includes(tag);
+                tagSpan.className = `px-2 py-0.5 rounded text-xs ${isActive ? 'bg-green-600 text-white' : 'bg-gray-700 text-gray-300'}`;
+                tagSpan.textContent = tag;
+                tagsDiv.appendChild(tagSpan);
+            });
+            card.appendChild(tagsDiv);
+        }
+
+        return card;
+    }
+
+    // ── Image Viewer ──────────────────────────────────────────
+
+    async openImageViewer(prompt, startIndex) {
+        // Load all images for this prompt
+        let images = prompt.images || [];
+
+        // If there might be more images, load them all
+        if (prompt.image_count > images.length) {
+            try {
+                const resp = await fetch(`/prompt_manager/prompts/${prompt.id}/images`);
+                const data = await resp.json();
+                if (data.success && data.images) {
+                    images = data.images;
+                }
+            } catch (err) {
+                console.error('Failed to load all images:', err);
+            }
+        }
+
+        if (images.length === 0) {
+            this.admin.showNotification('No images found for this prompt', 'warning');
+            return;
+        }
+
+        // Create temp container for ViewerJS
+        const container = document.createElement('div');
+        container.style.display = 'none';
+
+        images.forEach((image, index) => {
+            const imageUrl = this.admin.getImageUrl(image);
+            if (!imageUrl) return;
+
+            const img = document.createElement('img');
+            img.src = imageUrl;
+            img.alt = image.filename || `Image ${index + 1}`;
+            container.appendChild(img);
+        });
+
+        document.body.appendChild(container);
+
+        const viewer = new Viewer(container, {
+            inline: false,
+            navbar: true,
+            toolbar: {
+                zoomIn: 1,
+                zoomOut: 1,
+                oneToOne: 1,
+                reset: 1,
+                prev: 1,
+                play: false,
+                next: 1,
+                rotateLeft: 1,
+                rotateRight: 1,
+                flipHorizontal: 1,
+                flipVertical: 1
+            },
+            title: [1, (image) => image.alt || 'Image'],
+            hidden: () => {
+                viewer.destroy();
+                container.remove();
+            },
+            initialViewIndex: Math.min(startIndex, images.length - 1)
+        });
+
+        viewer.show();
+    }
+
+    clearPrompts() {
+        this.prompts = [];
+        this.promptTotal = 0;
+        const grid = document.getElementById('tagPromptsGrid');
+        if (grid) grid.replaceChildren();
+        const emptyState = document.getElementById('tagPromptsEmpty');
+        if (emptyState) emptyState.classList.remove('hidden');
+        this.updatePromptCountBadge();
+    }
+
+    // ── Infinite Scroll ───────────────────────────────────────
+
+    initInfiniteScroll() {
+        // Tag list observer
+        const tagsLoader = document.getElementById('tagsLoader');
+        if (tagsLoader) {
+            this.tagObserver = new IntersectionObserver((entries) => {
+                if (entries[0].isIntersecting && this.hasMoreTags && !this.isLoadingTags) {
+                    this.loadMoreTags();
+                }
+            }, { root: document.getElementById('tagsListContainer'), threshold: 0.1 });
+            this.tagObserver.observe(tagsLoader);
+        }
+
+        // Prompts grid observer
+        const promptsLoader = document.getElementById('tagPromptsLoader');
+        if (promptsLoader) {
+            this.promptObserver = new IntersectionObserver((entries) => {
+                if (entries[0].isIntersecting && this.hasMorePrompts && !this.isLoadingPrompts) {
+                    this.loadMoreTagPrompts();
+                }
+            }, { root: document.getElementById('tagPromptsContainer'), threshold: 0.1 });
+            this.promptObserver.observe(promptsLoader);
+        }
+    }
+
+    destroyInfiniteScroll() {
+        if (this.tagObserver) {
+            this.tagObserver.disconnect();
+            this.tagObserver = null;
+        }
+        if (this.promptObserver) {
+            this.promptObserver.disconnect();
+            this.promptObserver = null;
+        }
+    }
+
+    // ── Events ────────────────────────────────────────────────
+
+    bindEvents() {
+        // Tag search (debounced)
+        const searchInput = document.getElementById('tagSearchInput');
+        if (searchInput) {
+            searchInput.addEventListener('input', () => {
+                clearTimeout(this.searchTimer);
+                this.searchTimer = setTimeout(() => {
+                    this.tagSearch = searchInput.value.trim();
+                    this.loadTagsList();
+                }, 300);
+            });
+        }
+
+        // Tag sort
+        const sortSelect = document.getElementById('tagSortSelect');
+        if (sortSelect) {
+            sortSelect.addEventListener('change', () => {
+                this.tagSort = sortSelect.value;
+                this.loadTagsList();
+            });
+        }
+
+        // Filter mode buttons
+        const andBtn = document.getElementById('filterModeAnd');
+        const orBtn = document.getElementById('filterModeOr');
+        if (andBtn) andBtn.addEventListener('click', () => this.setFilterMode('and'));
+        if (orBtn) orBtn.addEventListener('click', () => this.setFilterMode('or'));
+    }
+
+    destroy() {
+        this.destroyInfiniteScroll();
+        this.hideContextMenu();
+        clearTimeout(this.searchTimer);
+    }
+
+    // ── Helpers ───────────────────────────────────────────────
+
+    getThumbnailUrl(image) {
+        if (image.thumbnail_url) return image.thumbnail_url;
+        if (image.url) return image.url;
+        if (image.id) return `/prompt_manager/images/${image.id}/file`;
+        return '';
+    }
+}
+
+// Attach to window for global access
+if (typeof window !== 'undefined') {
+    window.TagsPageManager = TagsPageManager;
+}


### PR DESCRIPTION
## Summary
- **Bulk tag operations**: rename, delete, merge tags across all prompts via right-click context menu
- **Prompt card interaction**: click card → dashboard search; click thumbnail → ViewerJS full-resolution viewer
- **Visual polish**: usage bars on tags, prompt count badge, staggered card fade-in animations
- **URL-synced selection**: `#/tags/landscape,portrait?mode=or` persists tag selection across refresh
- **Untagged filter**: `[untagged]` entry at top of tag list shows prompts with no tags

## Test plan
- [ ] Right-click a tag → context menu appears with Rename/Delete/Merge
- [ ] Rename tag → prompt dialog, tag list refreshes with new name
- [ ] Delete tag → confirm dialog, tag removed from list and prompts
- [ ] Merge tag → prompt for target, source tag disappears
- [ ] Click thumbnail → ViewerJS opens with full image and toolbar
- [ ] Click prompt card → navigates to dashboard with search populated
- [ ] Usage bars visible behind each tag showing relative frequency
- [ ] Selecting tags updates URL hash; refreshing page restores selection
- [ ] [untagged] item shows count; clicking loads untagged prompts
- [ ] Prompt count badge shows "X of Y prompts" in right panel
- [ ] Phase 1 features (search, sort, multi-filter, infinite scroll) still work