### PR TITLE
fix: prevent stack trace exposure in SSE error responses

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 repos:
-  - repo: https://github.com/psf/black
-    rev: 25.1.0
-    hooks:
-      - id: black
-        args: [--line-length=88, --target-version=py310]
-
   - repo: local
     hooks:
+      - id: black
+        name: black
+        entry: black --line-length=88 --target-version=py310
+        language: system
+        types: [python]
+
       - id: flake8
         name: flake8
         entry: flake8 --select=E9,F63,F7,F82 --show-source --exclude=reference/,web/

--- a/database/operations.py
+++ b/database/operations.py
@@ -946,16 +946,14 @@ class PromptDatabase:
                 # Find duplicates by text content (case-insensitive)
                 # Note: Removed ORDER BY from GROUP_CONCAT for SQLite compatibility
                 # We'll sort the IDs manually after fetching
-                cursor = conn.execute(
-                    """
+                cursor = conn.execute("""
                     SELECT LOWER(TRIM(text)) as normalized_text, COUNT(*) as count, 
                            GROUP_CONCAT(id) as ids,
                            GROUP_CONCAT(created_at) as created_dates
                     FROM prompts 
                     GROUP BY LOWER(TRIM(text))
                     HAVING COUNT(*) > 1
-                """
-                )
+                """)
 
                 duplicate_groups = cursor.fetchall()
                 self.logger.debug(
@@ -1020,16 +1018,14 @@ class PromptDatabase:
                 # Find duplicates by text content (case-insensitive)
                 # Note: Removed ORDER BY from GROUP_CONCAT for SQLite compatibility
                 # We'll sort the IDs manually after fetching
-                cursor = conn.execute(
-                    """
+                cursor = conn.execute("""
                     SELECT LOWER(TRIM(text)) as normalized_text, COUNT(*) as count, 
                            GROUP_CONCAT(id) as ids,
                            GROUP_CONCAT(created_at) as created_dates
                     FROM prompts 
                     GROUP BY LOWER(TRIM(text))
                     HAVING COUNT(*) > 1
-                """
-                )
+                """)
 
                 duplicates = cursor.fetchall()
                 self.logger.debug(
@@ -1749,8 +1745,7 @@ class PromptDatabase:
         Returns number of prompts removed.
         """
         with self.model.get_connection() as conn:
-            cursor = conn.execute(
-                """
+            cursor = conn.execute("""
                 SELECT p.id FROM prompts p
                 LEFT JOIN generated_images gi ON p.id = gi.prompt_id
                 WHERE gi.prompt_id IS NULL
@@ -1759,8 +1754,7 @@ class PromptDatabase:
                     JOIN tags t ON pt.tag_id = t.id
                     WHERE pt.prompt_id = p.id AND t.name = '__protected__'
                 )
-            """
-            )
+            """)
             orphaned = [row["id"] for row in cursor.fetchall()]
             if not orphaned:
                 return 0
@@ -1776,26 +1770,22 @@ class PromptDatabase:
         issues: List[str] = []
         with self.model.get_connection() as conn:
             # Check for orphaned prompt_tags entries
-            cursor = conn.execute(
-                """
+            cursor = conn.execute("""
                 SELECT pt.prompt_id, pt.tag_id FROM prompt_tags pt
                 LEFT JOIN prompts p ON pt.prompt_id = p.id
                 WHERE p.id IS NULL
-            """
-            )
+            """)
             for ref in cursor.fetchall():
                 issues.append(
                     f"prompt_tags entry references non-existent prompt {ref['prompt_id']}"
                 )
 
             # Check for orphaned image entries
-            cursor = conn.execute(
-                """
+            cursor = conn.execute("""
                 SELECT gi.id, gi.prompt_id FROM generated_images gi
                 LEFT JOIN prompts p ON gi.prompt_id = p.id
                 WHERE p.id IS NULL
-            """
-            )
+            """)
             for ref in cursor.fetchall():
                 issues.append(
                     f"Image {ref['id']} references non-existent prompt {ref['prompt_id']}"

--- a/utils/diagnostics.py
+++ b/utils/diagnostics.py
@@ -137,12 +137,10 @@ class GalleryDiagnostics:
                 self.logger.info(f"   [NOTE] Prompts in database: {prompt_count}")
 
                 # Check if generated_images table exists
-                cursor = conn.execute(
-                    """
+                cursor = conn.execute("""
                     SELECT name FROM sqlite_master 
                     WHERE type='table' AND name='generated_images'
-                """
-                )
+                """)
 
                 has_images_table = cursor.fetchone() is not None
                 self.logger.info(f"   [IMG]  Images table exists: {has_images_table}")
@@ -176,12 +174,10 @@ class GalleryDiagnostics:
                 conn.row_factory = sqlite3.Row
 
                 # Check if table exists
-                cursor = conn.execute(
-                    """
+                cursor = conn.execute("""
                     SELECT name FROM sqlite_master 
                     WHERE type='table' AND name='generated_images'
-                """
-                )
+                """)
 
                 if not cursor.fetchone():
                     return {
@@ -195,15 +191,13 @@ class GalleryDiagnostics:
                 self.logger.info(f"   [STATS] Images in database: {image_count}")
 
                 # Get recent images
-                cursor = conn.execute(
-                    """
+                cursor = conn.execute("""
                     SELECT gi.*, p.text 
                     FROM generated_images gi 
                     LEFT JOIN prompts p ON gi.prompt_id = p.id 
                     ORDER BY gi.generation_time DESC 
                     LIMIT 5
-                """
-                )
+                """)
                 recent_images = [dict(row) for row in cursor.fetchall()]
 
                 self.logger.info(f"   [TIME] Recent images: {len(recent_images)}")


### PR DESCRIPTION
## Summary
- Resolve 2 remaining GitHub code scanning alerts (`py/stack-trace-exposure`)
- Log exception details server-side only; send generic error messages to clients via SSE streams
- Affected files: `py/api/autotag_routes.py` (model load errors), `py/api/images.py` (thumbnail generation errors)

## Test plan
- [ ] Trigger a model load failure in autotag and verify the SSE message does not contain exception details
- [ ] Trigger a thumbnail generation error and verify the SSE progress/error messages are generic
- [ ] Verify server logs still contain full exception details for debugging