### PR TITLE
fix: custom image scan directory ignored due to wrong import

### DIFF
--- a/utils/image_monitor.py
+++ b/utils/image_monitor.py
@@ -304,28 +304,22 @@ class ImageMonitor:
             self.logger.warning("Image monitoring already running")
             return
 
-        # Check if monitoring is enabled in config
+        # Check config for monitoring settings
         try:
             from ..py.config import GalleryConfig
 
             if not GalleryConfig.MONITORING_ENABLED:
                 self.logger.info("Image monitoring disabled in config")
                 return
+
+            # Use configured directories if set
+            if not output_directories and GalleryConfig.MONITORING_DIRECTORIES:
+                output_directories = GalleryConfig.MONITORING_DIRECTORIES
+                self.logger.info(
+                    f"Using configured monitoring directories: {output_directories}"
+                )
         except Exception:
             pass
-
-        # Check config first, then auto-detect if not configured
-        if not output_directories:
-            try:
-                from py.config import GalleryConfig
-
-                if GalleryConfig.MONITORING_DIRECTORIES:
-                    output_directories = GalleryConfig.MONITORING_DIRECTORIES
-                    self.logger.info(
-                        f"Using configured monitoring directories: {output_directories}"
-                    )
-            except ImportError:
-                pass
 
         # Auto-detect ComfyUI output directory if still none
         if not output_directories:


### PR DESCRIPTION
Fixes #108

## Summary
- `start_monitoring()` used an absolute import (`from py.config import GalleryConfig`) to read `MONITORING_DIRECTORIES`, while the rest of the file used relative imports (`from ..py.config import ...`)
- The absolute import either raised `ImportError` (silently caught) or loaded a separate module instance with empty defaults
- Result: the user's configured scan directory was never picked up, and auto-detection always returned the default ComfyUI output folder
- Fixed by consolidating both config reads into the single relative import that already worked

## Test plan
- [ ] Set a custom Image Scan Directory in settings, restart ComfyUI, verify the custom directory is monitored
- [ ] Clear the custom directory, restart, verify auto-detection still works
- [ ] Verify on Windows with a path like `D:\ComfyUI\output`