### PR TITLE
fix: resolve UnboundLocalError and connected text input issues (#123)

### DIFF
--- a/prompt_manager.py
+++ b/prompt_manager.py
@@ -139,12 +139,14 @@ class PromptManager(PromptManagerBase, ComfyNodeABC):
             RuntimeError: If clip input is invalid
         """
         # Combine prepend, main text, and append text
-        final_text = ""
+        parts = []
         if prepend_text and prepend_text.strip():
-            final_text += prepend_text.strip() + " "
-        final_text += text if text else ""
+            parts.append(prepend_text.strip())
+        if text:
+            parts.append(text)
         if append_text and append_text.strip():
-            final_text += " " + append_text.strip()
+            parts.append(append_text.strip())
+        final_text = " ".join(parts)
 
         # Use the combined text for encoding
         encoding_text = final_text

--- a/prompt_manager.py
+++ b/prompt_manager.py
@@ -164,6 +164,7 @@ class PromptManager(PromptManagerBase, ComfyNodeABC):
 
         # Save prompt to database and set execution context for gallery tracking
         prompt_id = None
+        extended_tags = []
         if storage_text and storage_text.strip():
             self.logger.debug(f"Processing prompt text: {storage_text[:100]}...")
 

--- a/prompt_manager_text.py
+++ b/prompt_manager_text.py
@@ -145,6 +145,7 @@ class PromptManagerText(PromptManagerBase, ComfyNodeABC):
 
         # Save prompt to database and set execution context for gallery tracking
         prompt_id = None
+        extended_tags = []
         if storage_text and storage_text.strip():
             self.logger.debug(f"Processing prompt text: {storage_text[:100]}...")
 

--- a/prompt_manager_text.py
+++ b/prompt_manager_text.py
@@ -133,12 +133,14 @@ class PromptManagerText(PromptManagerBase, ComfyNodeABC):
             Tuple containing the final processed text string
         """
         # Combine prepend, main text, and append text
-        final_text = ""
+        parts = []
         if prepend_text and prepend_text.strip():
-            final_text += prepend_text.strip() + " "
-        final_text += text
+            parts.append(prepend_text.strip())
+        if text:
+            parts.append(text)
         if append_text and append_text.strip():
-            final_text += " " + append_text.strip()
+            parts.append(append_text.strip())
+        final_text = " ".join(parts)
 
         # For database storage, save the original main text with metadata about prepend/append
         storage_text = text

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "promptmanager"
 description = "A powerful ComfyUI custom node that extends the standard text encoder with persistent prompt storage, advanced search capabilities, and an automatic image gallery system using SQLite."
-version = "3.1.2"
+version = "3.1.3"
 license = {file = "LICENSE"}
 dependencies = ["# Core dependencies for PromptManager", "# Note: Most dependencies are already included with ComfyUI", "# Already included with Python standard library:", "# - sqlite3", "# - hashlib", "# - json", "# - datetime", "# - os", "# - typing", "# - threading", "# - uuid", "# Required for gallery functionality:", "watchdog>=2.1.0              # For file system monitoring", "Pillow>=8.0.0                # For image metadata extraction (usually included with ComfyUI)", "# Optional dependencies for enhanced search functionality:", "# fuzzywuzzy[speedup]>=0.18.0  # For fuzzy string matching (optional)", "# sqlalchemy>=1.4.0            # For advanced ORM features (optional)", "# Development dependencies (optional):", "# pytest>=6.0.0                # For running tests", "# black>=22.0.0                # For code formatting", "# flake8>=4.0.0                # For linting", "# mypy>=0.910                   # For type checking"]
 

--- a/tests/test_empty_text_handling.py
+++ b/tests/test_empty_text_handling.py
@@ -163,5 +163,90 @@ class TestPromptManagerEmptyInput(unittest.TestCase):
         self.assertEqual(result[1], "before main prompt after")
 
 
+@patch("prompt_manager_base.get_image_monitor")
+@patch("prompt_manager_base.get_prompt_tracker")
+@patch("prompt_manager_base.get_comfyui_integration")
+@patch("prompt_manager_base.PromptDatabase")
+class TestConnectedTextInput(unittest.TestCase):
+    """Test that externally connected text is preserved in output (issue #123).
+
+    When text comes from a connected node (not the widget), the Python side
+    must include it in the final output. The JS fix ensures the connected
+    value reaches Python; these tests verify Python handles it correctly.
+    """
+
+    def _make_text_node(self, mock_db_class, mock_integ, mock_tracker, mock_monitor):
+        mock_db = Mock()
+        mock_db_class.return_value = mock_db
+        mock_db.save_prompt.return_value = 1
+        mock_db.get_prompt_by_hash.return_value = None
+        from prompt_manager_text import PromptManagerText
+
+        return PromptManagerText()
+
+    def _make_clip_node(self, mock_db_class, mock_integ, mock_tracker, mock_monitor):
+        mock_db = Mock()
+        mock_db_class.return_value = mock_db
+        mock_db.save_prompt.return_value = 1
+        mock_db.get_prompt_by_hash.return_value = None
+        mock_clip = Mock()
+        mock_clip.tokenize.return_value = "mock_tokens"
+        mock_clip.encode_from_tokens_scheduled.return_value = "mock_cond"
+        from prompt_manager import PromptManager
+
+        return PromptManager(), mock_clip
+
+    def test_text_node_connected_text_with_prepend_append(
+        self, mock_db, mock_integ, mock_tracker, mock_monitor
+    ):
+        """Simulates screenshot: connected text + prepend + append must all appear."""
+        node = self._make_text_node(mock_db, mock_integ, mock_tracker, mock_monitor)
+        result = node.process_text(
+            text="This is the prompt",
+            prepend_text="This is prepend text",
+            append_text="This is append text",
+        )
+        self.assertEqual(
+            result[0],
+            "This is prepend text This is the prompt This is append text",
+        )
+
+    def test_text_node_connected_text_only(
+        self, mock_db, mock_integ, mock_tracker, mock_monitor
+    ):
+        """Connected text without prepend/append passes through unchanged."""
+        node = self._make_text_node(mock_db, mock_integ, mock_tracker, mock_monitor)
+        result = node.process_text(text="This is the prompt")
+        self.assertEqual(result[0], "This is the prompt")
+
+    def test_clip_node_connected_text_with_prepend_append(
+        self, mock_db, mock_integ, mock_tracker, mock_monitor
+    ):
+        """Same scenario for PromptManager (CLIP variant)."""
+        node, clip = self._make_clip_node(
+            mock_db, mock_integ, mock_tracker, mock_monitor
+        )
+        result = node.encode_prompt(
+            clip=clip,
+            text="This is the prompt",
+            prepend_text="This is prepend text",
+            append_text="This is append text",
+        )
+        self.assertEqual(
+            result[1],
+            "This is prepend text This is the prompt This is append text",
+        )
+
+    def test_clip_node_connected_text_only(
+        self, mock_db, mock_integ, mock_tracker, mock_monitor
+    ):
+        """Connected text without prepend/append passes through unchanged."""
+        node, clip = self._make_clip_node(
+            mock_db, mock_integ, mock_tracker, mock_monitor
+        )
+        result = node.encode_prompt(clip=clip, text="This is the prompt")
+        self.assertEqual(result[1], "This is the prompt")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_empty_text_handling.py
+++ b/tests/test_empty_text_handling.py
@@ -1,0 +1,139 @@
+"""
+Tests for issue #123: UnboundLocalError when Text input is empty.
+
+Verifies that PromptManagerText.process_text() and PromptManager.encode_prompt()
+handle empty/blank text inputs without raising UnboundLocalError on extended_tags.
+"""
+
+import os
+import sys
+import unittest
+from unittest.mock import Mock, patch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+@patch("prompt_manager_base.get_image_monitor")
+@patch("prompt_manager_base.get_prompt_tracker")
+@patch("prompt_manager_base.get_comfyui_integration")
+@patch("prompt_manager_base.PromptDatabase")
+class TestPromptManagerTextEmptyInput(unittest.TestCase):
+    """Test PromptManagerText with empty/blank text inputs (issue #123)."""
+
+    def _make_node(self, mock_db_class, mock_integration, mock_tracker, mock_monitor):
+        mock_db = Mock()
+        mock_db_class.return_value = mock_db
+        mock_db.save_prompt.return_value = 1
+        mock_db.get_prompt_by_hash.return_value = None
+
+        from prompt_manager_text import PromptManagerText
+
+        return PromptManagerText()
+
+    def test_empty_string(self, mock_db, mock_integ, mock_tracker, mock_monitor):
+        """Empty string should not raise UnboundLocalError."""
+        node = self._make_node(mock_db, mock_integ, mock_tracker, mock_monitor)
+        result = node.process_text(text="")
+        self.assertIsInstance(result, tuple)
+        self.assertEqual(result[0], "")
+
+    def test_whitespace_only(self, mock_db, mock_integ, mock_tracker, mock_monitor):
+        """Whitespace-only string should not raise UnboundLocalError."""
+        node = self._make_node(mock_db, mock_integ, mock_tracker, mock_monitor)
+        result = node.process_text(text="   ")
+        self.assertIsInstance(result, tuple)
+
+    def test_none_coerced_empty(self, mock_db, mock_integ, mock_tracker, mock_monitor):
+        """Falsy text value should not raise UnboundLocalError."""
+        node = self._make_node(mock_db, mock_integ, mock_tracker, mock_monitor)
+        # ComfyUI may pass empty string for unconnected inputs
+        result = node.process_text(text="", category="", tags="")
+        self.assertIsInstance(result, tuple)
+
+    def test_empty_text_with_prepend_append(
+        self, mock_db, mock_integ, mock_tracker, mock_monitor
+    ):
+        """Empty main text with prepend/append should still work."""
+        node = self._make_node(mock_db, mock_integ, mock_tracker, mock_monitor)
+        result = node.process_text(text="", prepend_text="before", append_text="after")
+        self.assertIsInstance(result, tuple)
+        self.assertIn("before", result[0])
+        self.assertIn("after", result[0])
+
+    def test_valid_text_still_works(
+        self, mock_db, mock_integ, mock_tracker, mock_monitor
+    ):
+        """Normal text input should continue to work correctly."""
+        node = self._make_node(mock_db, mock_integ, mock_tracker, mock_monitor)
+        result = node.process_text(text="a beautiful sunset")
+        self.assertIsInstance(result, tuple)
+        self.assertEqual(result[0], "a beautiful sunset")
+
+
+@patch("prompt_manager_base.get_image_monitor")
+@patch("prompt_manager_base.get_prompt_tracker")
+@patch("prompt_manager_base.get_comfyui_integration")
+@patch("prompt_manager_base.PromptDatabase")
+class TestPromptManagerEmptyInput(unittest.TestCase):
+    """Test PromptManager (CLIP variant) with empty/blank text inputs (issue #123)."""
+
+    def _make_node_and_clip(
+        self, mock_db_class, mock_integration, mock_tracker, mock_monitor
+    ):
+        mock_db = Mock()
+        mock_db_class.return_value = mock_db
+        mock_db.save_prompt.return_value = 1
+        mock_db.get_prompt_by_hash.return_value = None
+
+        mock_clip = Mock()
+        mock_clip.tokenize.return_value = "mock_tokens"
+        mock_clip.encode_from_tokens_scheduled.return_value = "mock_cond"
+
+        from prompt_manager import PromptManager
+
+        return PromptManager(), mock_clip
+
+    def test_empty_string(self, mock_db, mock_integ, mock_tracker, mock_monitor):
+        """Empty string should not raise UnboundLocalError."""
+        node, clip = self._make_node_and_clip(
+            mock_db, mock_integ, mock_tracker, mock_monitor
+        )
+        result = node.encode_prompt(clip=clip, text="")
+        self.assertIsInstance(result, tuple)
+
+    def test_whitespace_only(self, mock_db, mock_integ, mock_tracker, mock_monitor):
+        """Whitespace-only string should not raise UnboundLocalError."""
+        node, clip = self._make_node_and_clip(
+            mock_db, mock_integ, mock_tracker, mock_monitor
+        )
+        result = node.encode_prompt(clip=clip, text="   ")
+        self.assertIsInstance(result, tuple)
+
+    def test_empty_text_with_prepend_append(
+        self, mock_db, mock_integ, mock_tracker, mock_monitor
+    ):
+        """Empty main text with prepend/append should still work."""
+        node, clip = self._make_node_and_clip(
+            mock_db, mock_integ, mock_tracker, mock_monitor
+        )
+        result = node.encode_prompt(
+            clip=clip, text="", prepend_text="before", append_text="after"
+        )
+        self.assertIsInstance(result, tuple)
+        self.assertIn("before", result[1])
+        self.assertIn("after", result[1])
+
+    def test_valid_text_still_works(
+        self, mock_db, mock_integ, mock_tracker, mock_monitor
+    ):
+        """Normal text input should continue to work correctly."""
+        node, clip = self._make_node_and_clip(
+            mock_db, mock_integ, mock_tracker, mock_monitor
+        )
+        result = node.encode_prompt(clip=clip, text="a beautiful sunset")
+        self.assertIsInstance(result, tuple)
+        self.assertEqual(result[1], "a beautiful sunset")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_empty_text_handling.py
+++ b/tests/test_empty_text_handling.py
@@ -53,12 +53,12 @@ class TestPromptManagerTextEmptyInput(unittest.TestCase):
     def test_empty_text_with_prepend_append(
         self, mock_db, mock_integ, mock_tracker, mock_monitor
     ):
-        """Empty main text with prepend/append should still work."""
+        """Empty main text with prepend/append should produce single space, not double."""
         node = self._make_node(mock_db, mock_integ, mock_tracker, mock_monitor)
         result = node.process_text(text="", prepend_text="before", append_text="after")
         self.assertIsInstance(result, tuple)
-        self.assertIn("before", result[0])
-        self.assertIn("after", result[0])
+        self.assertEqual(result[0], "before after")
+        self.assertNotIn("  ", result[0])
 
     def test_valid_text_still_works(
         self, mock_db, mock_integ, mock_tracker, mock_monitor
@@ -68,6 +68,22 @@ class TestPromptManagerTextEmptyInput(unittest.TestCase):
         result = node.process_text(text="a beautiful sunset")
         self.assertIsInstance(result, tuple)
         self.assertEqual(result[0], "a beautiful sunset")
+
+    def test_prepend_text_append_all_present(
+        self, mock_db, mock_integ, mock_tracker, mock_monitor
+    ):
+        """All three parts should combine with single spaces."""
+        node = self._make_node(mock_db, mock_integ, mock_tracker, mock_monitor)
+        result = node.process_text(
+            text="main prompt", prepend_text="before", append_text="after"
+        )
+        self.assertEqual(result[0], "before main prompt after")
+
+    def test_only_prepend(self, mock_db, mock_integ, mock_tracker, mock_monitor):
+        """Prepend with empty text should output just prepend."""
+        node = self._make_node(mock_db, mock_integ, mock_tracker, mock_monitor)
+        result = node.process_text(text="", prepend_text="before")
+        self.assertEqual(result[0], "before")
 
 
 @patch("prompt_manager_base.get_image_monitor")
@@ -112,7 +128,7 @@ class TestPromptManagerEmptyInput(unittest.TestCase):
     def test_empty_text_with_prepend_append(
         self, mock_db, mock_integ, mock_tracker, mock_monitor
     ):
-        """Empty main text with prepend/append should still work."""
+        """Empty main text with prepend/append should produce single space, not double."""
         node, clip = self._make_node_and_clip(
             mock_db, mock_integ, mock_tracker, mock_monitor
         )
@@ -120,8 +136,8 @@ class TestPromptManagerEmptyInput(unittest.TestCase):
             clip=clip, text="", prepend_text="before", append_text="after"
         )
         self.assertIsInstance(result, tuple)
-        self.assertIn("before", result[1])
-        self.assertIn("after", result[1])
+        self.assertEqual(result[1], "before after")
+        self.assertNotIn("  ", result[1])
 
     def test_valid_text_still_works(
         self, mock_db, mock_integ, mock_tracker, mock_monitor
@@ -133,6 +149,18 @@ class TestPromptManagerEmptyInput(unittest.TestCase):
         result = node.encode_prompt(clip=clip, text="a beautiful sunset")
         self.assertIsInstance(result, tuple)
         self.assertEqual(result[1], "a beautiful sunset")
+
+    def test_prepend_text_append_all_present(
+        self, mock_db, mock_integ, mock_tracker, mock_monitor
+    ):
+        """All three parts should combine with single spaces."""
+        node, clip = self._make_node_and_clip(
+            mock_db, mock_integ, mock_tracker, mock_monitor
+        )
+        result = node.encode_prompt(
+            clip=clip, text="main prompt", prepend_text="before", append_text="after"
+        )
+        self.assertEqual(result[1], "before main prompt after")
 
 
 if __name__ == "__main__":

--- a/web/prompt_manager.js
+++ b/web/prompt_manager.js
@@ -186,18 +186,22 @@ function syncPromptManagerWidgets() {
 
         node.widgets.forEach((widget, idx) => {
           if (widget) {
-            // CRITICAL: For multiline widgets, inputEl.value is the true source
+            // Skip widgets whose input is connected to another node —
+            // the connected value takes precedence over the DOM widget value
+            const isConnected = node.inputs?.some(
+              i => i.name === widget.name && i.link != null
+            );
+            if (isConnected) return;
+
+            // For non-connected widgets, inputEl.value is the true source
             const actualValue = widget.inputEl ? widget.inputEl.value : widget.value;
             if (actualValue !== undefined) {
-              const oldValue = node.widgets_values[idx];
               node.widgets_values[idx] = actualValue;
 
               // Also sync widget.value
               if (widget.inputEl && widget.value !== actualValue) {
                 widget.value = actualValue;
               }
-
-              // text widget value synced from DOM
             }
           }
         });
@@ -235,13 +239,18 @@ app.registerExtension({
         const nodes = graph._nodes || graph.nodes || [];
         for (const node of nodes) {
           if ((node.type === "PromptManager" || node.type === "PromptManagerText") && output[node.id]) {
-            // Find the text widget and get its current DOM value
+            const outputNode = output[node.id];
+
+            // Skip if text input is connected to another node (value is a link reference array)
+            if (outputNode.inputs && Array.isArray(outputNode.inputs.text)) {
+              continue;
+            }
+
+            // Only sync widget DOM value for non-connected (widget-based) text inputs
             const textWidget = node.widgets?.find(w => w.name === "text");
             if (textWidget && textWidget.inputEl) {
               const currentValue = textWidget.inputEl.value;
-              const outputNode = output[node.id];
 
-              // The output structure has "inputs" with widget values
               if (outputNode.inputs && outputNode.inputs.text !== currentValue) {
                 outputNode.inputs.text = currentValue;
               }
@@ -403,20 +412,22 @@ app.registerExtension({
         // Hook into serialization to preserve resize flag, sync widget values, and prevent runtime data from being saved
         const originalSerialize = this.serialize;
         this.serialize = function () {
-          // CRITICAL: Sync widget values BEFORE serialization
-          // This ensures graphToPrompt reads current values, not cached ones
-          // For multiline widgets, the value is stored in inputEl.value
+          // Sync widget values BEFORE serialization, but only for non-connected widgets
           if (this.widgets && this.widgets.length > 0) {
             if (!this.widgets_values) {
               this.widgets_values = [];
             }
             this.widgets.forEach((widget, idx) => {
               if (widget) {
-                // Get the actual value - inputEl.value for DOM widgets, otherwise widget.value
+                // Skip connected widgets — their value comes from the link
+                const isConnected = self.inputs?.some(
+                  i => i.name === widget.name && i.link != null
+                );
+                if (isConnected) return;
+
                 const actualValue = widget.inputEl ? widget.inputEl.value : widget.value;
                 if (actualValue !== undefined) {
                   this.widgets_values[idx] = actualValue;
-                  // Sync widget.value with inputEl.value
                   if (widget.inputEl && widget.value !== actualValue) {
                     widget.value = actualValue;
                   }


### PR DESCRIPTION
## Summary

Fixes #123 — `UnboundLocalError` in `PromptManagerText` / `PromptManager` when text input is empty, plus two related bugs discovered during QA.

**Three layered bugs were found and fixed:**

1. **`UnboundLocalError` crash** — `extended_tags` was only assigned inside the `if storage_text` block but referenced unconditionally by `register_prompt()`. Fixed by initializing `extended_tags = []` before the conditional.

2. **Double-space in output** — When main text is empty with prepend/append connected, the old string concatenation produced `"before  after"`. Switched to `" ".join(parts)` so empty text is cleanly skipped.

3. **Connected text input silently dropped** — The JS `queuePrompt` interceptor, `syncPromptManagerWidgets()`, and `serialize` hook were overwriting ComfyUI's valid link references with the widget's empty DOM value. Added connection checks (`Array.isArray()` for link refs, `input.link != null` for widget sync) so externally connected text flows through correctly.

### Files changed
- `prompt_manager.py` — init `extended_tags`, parts-based concatenation
- `prompt_manager_text.py` — same fixes
- `web/prompt_manager.js` — connection-aware widget sync
- `tests/test_empty_text_handling.py` — 16 new unit tests
- `pyproject.toml` — version bump to 3.1.3

## Test plan
- [x] 16 unit tests covering empty string, whitespace, prepend/append combinations, and connected-input contract
- [x] Existing test suite passes (21 total)
- [x] Pre-commit hooks pass (black, flake8, bandit)
- [ ] Manual QA: connect text node → PromptManagerText → Display Text (requires ComfyUI restart for JS changes)