### PR TITLE
fix(ui): enable click-to-close on image viewer (#125)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "promptmanager"
 description = "A powerful ComfyUI custom node that extends the standard text encoder with persistent prompt storage, advanced search capabilities, and an automatic image gallery system using SQLite."
-version = "3.1.3"
+version = "3.1.4"
 license = {file = "LICENSE"}
 dependencies = ["# Core dependencies for PromptManager", "# Note: Most dependencies are already included with ComfyUI", "# Already included with Python standard library:", "# - sqlite3", "# - hashlib", "# - json", "# - datetime", "# - os", "# - typing", "# - threading", "# - uuid", "# Required for gallery functionality:", "watchdog>=2.1.0              # For file system monitoring", "Pillow>=8.0.0                # For image metadata extraction (usually included with ComfyUI)", "# Optional dependencies for enhanced search functionality:", "# fuzzywuzzy[speedup]>=0.18.0  # For fuzzy string matching (optional)", "# sqlalchemy>=1.4.0            # For advanced ORM features (optional)", "# Development dependencies (optional):", "# pytest>=6.0.0                # For running tests", "# black>=22.0.0                # For code formatting", "# flake8>=4.0.0                # For linting", "# mypy>=0.910                   # For type checking"]
 

--- a/web/js/admin.js
+++ b/web/js/admin.js
@@ -1165,10 +1165,11 @@
                             flipVertical: 1,
                         },
                         navbar: true,
+                        button: true,
                         title: true,
                         transition: true,
                         keyboard: true,
-                        backdrop: 'static',
+                        backdrop: true,
                         loading: true,
                         loop: true,
                         tooltip: true,
@@ -3629,6 +3630,8 @@ Seed: ${this.currentMetadata.seed || 'Unknown'}`;
                 // Initialize ViewerJS
                 const viewer = new Viewer(container, {
                     inline: false,
+                    button: true,
+                    backdrop: true,
                     navbar: true,
                     toolbar: {
                         zoomIn: 1,

--- a/web/js/gallery.js
+++ b/web/js/gallery.js
@@ -337,6 +337,7 @@
                 this.viewer = new Viewer(container, {
                     inline: false,
                     button: true,
+                    backdrop: true,
                     navbar: true,
                     title: true,
                     // IMPORTANT: Use original images for viewing, not thumbnails


### PR DESCRIPTION
## Summary

Fixes #125 — Image viewer could only be closed with the ESC key.

**Root cause:** The admin gallery ViewerJS instance was configured with `backdrop: 'static'`, which disables click-to-close on the dark overlay.

**Changes:**
- `web/js/admin.js` — Changed `backdrop: 'static'` → `backdrop: true` on the admin gallery viewer, added explicit `button: true` (close button). Also added `button: true` and `backdrop: true` to the filmstrip viewer.
- `web/js/gallery.js` — Added explicit `backdrop: true` to the gallery page viewer (was using default, now explicit for consistency).
- `pyproject.toml` — Version bump to 3.1.4

Users can now close the image viewer by:
1. Clicking the dark overlay/backdrop area
2. Clicking the × close button (top-right)
3. Pressing ESC (existing behavior)

## Test plan
- [ ] Open image viewer from admin gallery tab → click backdrop → viewer closes
- [ ] Open image viewer from gallery page → click backdrop → viewer closes  
- [ ] Open filmstrip viewer from prompt detail → click backdrop → viewer closes
- [ ] Verify ESC still works in all viewers
- [ ] Verify close button (×) visible in top-right corner